### PR TITLE
Introduce Cobra as the command line interface for the application

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -6,8 +6,7 @@ The final description as to why and how things are done is, and will remain, ver
 
 ## File Layout
 
-| Package/Directory | Description                                                                                   |
-|:------------------|:----------------------------------------------------------------------------------------------|
-| link              | The entrypoint for the application that handles the actual redirect. (www.EXAMPLE.COM/SHORT1) |
-
+| Package/Directory | Description                                                    |
+|:------------------|:---------------------------------------------------------------|
+| cmd               | The abbreviation of command (The command line interface files) |
  

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+	"os"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "url-shortner",
+	Short: "Link",
+	Long: `Take any lengthy URL and make it into something shorter
+
+A secondary purpose of this application is me(Moutaz Chaara) to sharpen my skills in GOLANG.
+If prospective employers come looking, here's some
+code!`,
+
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("This application still in WIP.")
+	},
+}
+
+// Execute adds all child commands to the root command and sets flags appropriately.
+// This is called by main() func. It only needs to happen once to the rootCmd.
+func Execute() {
+	err := rootCmd.Execute()
+	if err != nil {
+		os.Exit(1)
+	}
+}
+
+// init to declare configuration
+func init() {
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module github.com/tz3/url-shortner
+
+go 1.21rc4
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/cobra v1.8.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,7 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.8.0/go.mod h1:WXLWApfZ71AjXPya3WOlMsY9yMs7YeiHhFVlvLyhcho=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/link/link.go
+++ b/link/link.go
@@ -1,7 +1,0 @@
-package link
-
-import "fmt"
-
-func main() {
-	fmt.Println("main func...")
-}

--- a/main.go
+++ b/main.go
@@ -1,0 +1,7 @@
+package url_shortner
+
+import "github.com/tz3/url-shortner/cmd"
+
+func main() {
+	cmd.Execute()
+}


### PR DESCRIPTION
### Introduce Cobra as the command line interface for the application

This commit introduces several significant changes, with the main idea being a shift from having multiple distinct binaries. Instead, it proposes a single binary encompassing all the logic that can be activated through various "modes" such as server or client. The default mode is likely intended to be set as the client.

== Design Notes
=== Removing package "link"

In this commit, the "link" package is eliminated, as it was initially designed to accommodate multiple binaries. 
By removing this package, the associated subdirectory becomes obsolete and has been deleted to streamline the application's structure.

=== Cobra Library

This commit introduces the "cobra" library, and a subsequent commit will
probably introduce the "viper/gin" one. 
These libraries are useful just to provide an interface to applications, though they are not without some
quirks (e.g. testability of run methods).

The files were generated via:

  `$ cobra-cli init`

Some content was left there to be "filled out" later, as it is not in version control (and thus cannot be "safely"
deleted")