### PR TITLE
Add Deployment, Redirect serve and util. (#5)

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,3 @@
+# Deployment
+
+Will come later multiple ways of deployment

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -9,4 +9,8 @@ The final description as to why and how things are done is, and will remain, ver
 | Package/Directory | Description                                                    |
 |:------------------|:---------------------------------------------------------------|
 | cmd               | The abbreviation of command (The command line interface files) |
- 
+
+
+## Development & Deployment
+See Development Info :- [the development documentation](DEVELOPMENT.md).
+See Deployment  Info :- [deployment documentation](DEPLOYMENT.md)

--- a/cmd/exitcodes.go
+++ b/cmd/exitcodes.go
@@ -3,4 +3,5 @@ package cmd
 const (
 	ExitSuccess      = 0
 	ExitGeneralError = 1
+	ExitUsageError   = 64 // Used incorrectly
 )

--- a/cmd/redirect.go
+++ b/cmd/redirect.go
@@ -1,0 +1,16 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/tz3/url-shortner/cmd/redirect"
+)
+
+var redirectCmd = &cobra.Command{
+	Use:   "Redirect Urls",
+	Short: "Subcommand related to prediction of the urls",
+	RunE:  Noop,
+}
+
+func init() {
+	redirectCmd.AddCommand(redirect.Serve)
+}

--- a/cmd/redirect/server.go
+++ b/cmd/redirect/server.go
@@ -1,0 +1,27 @@
+package redirect
+
+import (
+	"github.com/spf13/cobra"
+	"net/http"
+)
+
+// Serve starts the HTTP server which will do the redirect.
+// shortUrl redirected to -> LongUrl (Original Destination)
+var Serve = &cobra.Command{
+	Use:   "serve",
+	Short: "Start the server that handles redirects",
+	RunE:  RunServe,
+}
+
+func RunServe(cmd *cobra.Command, args []string) error {
+	// Stub implementation to validate runtime constraints.
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		// FixMe:- Unhandled error
+		w.Write([]byte("ok"))
+	})
+
+	return http.ListenAndServe("localhost:8080", http.DefaultServeMux)
+}
+
+func init() {
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,17 +19,7 @@ code!`,
 	},
 }
 
-// Execute adds all child commands to the root command and sets flags appropriately.
-// This is called by main() func. It only needs to happen once to the root.
-func Execute(c *cobra.Command) int {
-	err := c.Execute()
-	if err != nil {
-		fmt.Println("Error:", err)
-		return ExitGeneralError
-	}
-	return ExitSuccess
-}
-
 // init to declare configuration
 func init() {
+	Root.AddCommand(redirectCmd)
 }

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+)
+
+// Execute adds all child commands to the root command and sets flags appropriately.
+// This is called by main() func. It only needs to happen once to the root.
+func Execute(c *cobra.Command) int {
+	err := c.Execute()
+	if err != nil {
+		fmt.Println("Error:", err)
+		return ExitGeneralError
+	}
+	return ExitSuccess
+}
+
+// Noop function simply indicates that this command, in and of itself, does nothing.
+func Noop(c *cobra.Command, args []string) error {
+	return fmt.Errorf("%w: required subcommand not supplied", ExitUsageError)
+}

--- a/cmd/util_test.go
+++ b/cmd/util_test.go
@@ -1,4 +1,4 @@
-// root_test.go
+// util_test.go
 package cmd
 
 import (


### PR DESCRIPTION
== Deployment Documentation
This commit define the deployment file, which is WIP will be added later.

== link redirect, redirect serve
Introduce multiple commands, that will be used when the functionality added.

The commands are assumed to have a stable API, however the
implementation of the functions is going to change substantially.

=== util
Create new file for util, which will have utility functionalities.
Currently there are only Excute function which moved from another file, and Noop function.
The later does nothing now.

Util name will be changed later after defining the file functionalities (avoid general names)