### PR TITLE
Introduce in-memory storage

### DIFF
--- a/storage/memory/hash_map.go
+++ b/storage/memory/hash_map.go
@@ -1,0 +1,47 @@
+package memory
+
+import (
+	"github.com/tz3/url-shortner/storage"
+	"net/url"
+	"sync"
+)
+
+// HashMap represents a data structure for mapping short strings to long URLs.
+type HashMap struct {
+	shortToLongMap map[string]*url.URL // Map to store short-to-long URL mappings.
+	mux            sync.Mutex          // Mutex for concurrent access control.
+}
+
+// NewHashMap creates a new instance of HashMap with an initialized map and mutex.
+func NewHashMap() *HashMap {
+	return &HashMap{
+		shortToLongMap: make(map[string]*url.URL),
+		mux:            sync.Mutex{},
+	}
+}
+
+// Get retrieves the long URL associated with a given short URL.
+func (hm *HashMap) Get(short *url.URL) (*url.URL, error) {
+	hm.mux.Lock()
+	defer hm.mux.Unlock()
+
+	v, ok := hm.shortToLongMap[short.String()]
+	if !ok {
+		return nil, storage.ErrorNotFound
+	}
+	return v, nil
+}
+
+// Set associates a short URL with a long URL in the HashMap.
+func (hm *HashMap) Set(short *url.URL, long *url.URL) error {
+	hm.mux.Lock()
+	defer hm.mux.Unlock()
+
+	if _, ok := hm.shortToLongMap[short.String()]; ok {
+		return storage.ErrorDupKey
+	}
+
+	// Set the short-to-long URL mapping.
+	hm.shortToLongMap[short.String()] = long
+	return nil
+}

--- a/storage/memory/hash_map_test.go
+++ b/storage/memory/hash_map_test.go
@@ -1,0 +1,40 @@
+package memory
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/tz3/url-shortner/storage/memory/test"
+	"net/url"
+	"testing"
+)
+
+func BenchmarkHashTable10(b *testing.B) {
+	test.BenchmarkStorage(b, NewHashMap(), 10)
+}
+
+func BenchmarkHashTable100(b *testing.B) {
+	test.BenchmarkStorage(b, NewHashMap(), 100)
+}
+
+func BenchmarkHashTable100000(b *testing.B) {
+	test.BenchmarkStorage(b, NewHashMap(), 100000)
+}
+
+func TestNewHashMap(t *testing.T) {
+	t.Parallel()
+
+	hm := NewHashMap()
+	hm.Set(&url.URL{
+		Host: "short1",
+	}, &url.URL{
+		Host: "long1.com",
+	})
+
+	res, err := hm.Get(&url.URL{
+		Host: "short1",
+	})
+
+	assert.Nil(t, err)
+	assert.Equal(t, &url.URL{
+		Host: "long1.com",
+	}, res)
+}

--- a/storage/memory/test/storage.go
+++ b/storage/memory/test/storage.go
@@ -1,0 +1,44 @@
+package test
+
+import (
+	"encoding/base64"
+	"github.com/tz3/url-shortner/storage"
+	"math/rand"
+	"net/url"
+	"testing"
+)
+
+const seed = 42
+
+func BenchmarkStorage(b *testing.B, str storage.Repository, iter int64) {
+	// Generate the URLs randomly. Uses Rand.Read() and Base64 URL safe encoding to generate
+	// "fairly random" URLs, creating a large, unsorted array. All URLs point to the same result, as this is
+	// outside the scope of the benchmark.
+	urls := []*url.URL{}
+	long := &url.URL{
+		Host: "google.com",
+		Path: "/benchmarks",
+	}
+
+	rand := rand.New(rand.NewSource(seed))
+	var i int64
+	for i = 0; i <= iter; i++ {
+
+		bytes := make([]byte, 10)
+		rand.Read(bytes)
+
+		short := &url.URL{
+			Host: "s3k",
+			Path: base64.URLEncoding.EncodeToString(bytes),
+		}
+		urls = append(urls, long)
+		str.Set(short, long)
+
+	}
+
+	// Iterate through the whole list, finding them all. Actual benchmark.
+	b.ResetTimer()
+	for _, u := range urls {
+		str.Get(u)
+	}
+}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -7,9 +7,11 @@ import (
 
 var (
 	ErrorNotFound          = errors.New("NOT_FOUND_ERROR")
+	ErrorDupKey            = errors.New("FAILED_DUPLICATED_ID")
 	ErrorStorageInitFailed = errors.New("FAILED_STORAGE_INIT")
 )
 
-type Storage interface {
+type Repository interface {
 	Get(url *url.URL) (*url.URL, error)
+	Set(short *url.URL, long *url.URL) error
 }


### PR DESCRIPTION
### Introduce in-memory storage

## Addtion in this commit:-
1. new in-memory storage mechanisim was introduced (in-memory) sotring mechanisim.
2. Benchmark tests were added, as I want in future to add multiple other options for storage, and benchmark will help us to make a conclusion on that.
3. New unit tests and benchmark tests.

## Modifications in this commit:-
Change the storage interface from `type Sotrage interface` TO `type Repository interface` => this modification is because it is more convenient to stay with convention names **Repository Patteren** which came from **Interface segregation pattern**.
