### PR TITLE
Implement yaml handler (#10)

### DIFF
--- a/storage/storage.go
+++ b/storage/storage.go
@@ -9,6 +9,7 @@ var (
 	ErrorNotFound          = errors.New("NOT_FOUND_ERROR")
 	ErrorDupKey            = errors.New("FAILED_DUPLICATED_ID")
 	ErrorStorageInitFailed = errors.New("FAILED_STORAGE_INIT")
+	ErrReadOnlyStorage     = errors.New("FAILED_READ_ONLY_STORAGE_TYPE")
 )
 
 type Repository interface {

--- a/storage/tests/test.go
+++ b/storage/tests/test.go
@@ -33,7 +33,7 @@ func WithError(err error) TestOption {
 	}
 }
 
-// see storage.Storer
+// Get see storage.Repository
 func (ts *ts) Get(u *url.URL) (*url.URL, error) {
 	if ts.err != nil {
 		return nil, ts.err
@@ -46,7 +46,7 @@ func (ts *ts) Get(u *url.URL) (*url.URL, error) {
 	return nil, storage.ErrorNotFound
 }
 
-// see storage.Storer
+// Set see storage.Repository
 func (ts *ts) Set(f *url.URL, t *url.URL) error {
 	if ts.err != nil {
 		return ts.err

--- a/storage/tests/test.go
+++ b/storage/tests/test.go
@@ -1,0 +1,57 @@
+package tests
+
+import (
+	"github.com/tz3/url-shortner/storage"
+	"net/url"
+)
+
+type TestOption func(t *ts)
+
+type ts struct {
+	r map[string]*url.URL
+
+	// error will modify the test structure to return an error for all operations.
+	err error
+}
+
+// New generates the test storage implementation
+func New(opts ...TestOption) *ts {
+	n := &ts{}
+
+	for _, o := range opts {
+		o(n)
+	}
+
+	return n
+}
+
+// WithError modifies the storage implementation such that any operation executed against it will return
+// an error.
+func WithError(err error) TestOption {
+	return func(t *ts) {
+		t.err = err
+	}
+}
+
+// see storage.Storer
+func (ts *ts) Get(u *url.URL) (*url.URL, error) {
+	if ts.err != nil {
+		return nil, ts.err
+	}
+
+	if v, ok := ts.r[u.String()]; ok {
+		return v, nil
+	}
+
+	return nil, storage.ErrorNotFound
+}
+
+// see storage.Storer
+func (ts *ts) Set(f *url.URL, t *url.URL) error {
+	if ts.err != nil {
+		return ts.err
+	}
+
+	ts.r[f.String()] = t
+	return nil
+}

--- a/storage/yaml/yaml.go
+++ b/storage/yaml/yaml.go
@@ -1,0 +1,67 @@
+package yaml
+
+import (
+	"fmt"
+	"github.com/tz3/url-shortner/storage"
+	parser "gopkg.in/yaml.v3"
+	"io"
+	"log/slog"
+	"net/url"
+)
+
+var Log *slog.Logger = slog.Default()
+
+// yaml represents a URL shortener backed by YAML storage.
+type yaml struct {
+	repo storage.Repository
+}
+
+// row represents a YAML entry with Short and Long URL mappings.
+type row struct {
+	Short string `yaml:"short"` // Short is the source URL that will be redirected.
+	Long  string `yaml:"long"`  // Long is the destination URL to which the source will be redirected.
+}
+
+// New creates a new YAML-backed URL shortener using the provided storage repository and input reader.
+func New(repo storage.Repository, src io.Reader) (*yaml, error) {
+	y := &yaml{repo: repo}
+
+	// Read the content into a structure that we can convert it to URLs
+	rows := make([]row, 0)
+	dec := parser.NewDecoder(src)
+	err := dec.Decode(&rows)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %s", storage.ErrorStorageInitFailed, err)
+	}
+
+	// Fill up the storage with the links
+	for _, r := range rows {
+		from, err := url.Parse(r.Short)
+		if err != nil {
+			Log.Debug("failed to parse from log", "url", r.Short, "err", err)
+			continue
+		}
+
+		to, err := url.Parse(r.Long)
+		if err != nil {
+			Log.Debug("failed to parse from log", "url", r.Long, "err", err)
+			continue
+		}
+
+		if err := y.repo.Set(from, to); err != nil {
+			return nil, fmt.Errorf("%w: %s", storage.ErrorStorageInitFailed, err)
+		}
+	}
+
+	return y, nil
+}
+
+// Get retrieves the destination URL for the given source URL from the storage.
+func (y *yaml) Get(u *url.URL) (*url.URL, error) {
+	return y.repo.Get(u)
+}
+
+// Set is not supported for YAML storage and always returns an error indicating read-only mode.
+func (y *yaml) Set(*url.URL, *url.URL) error {
+	return storage.ErrReadOnlyStorage
+}

--- a/storage/yaml/yaml_test.go
+++ b/storage/yaml/yaml_test.go
@@ -1,0 +1,136 @@
+package yaml
+
+import (
+	"bytes"
+	"errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/tz3/url-shortner/storage"
+	"github.com/tz3/url-shortner/storage/memory"
+	"github.com/tz3/url-shortner/storage/tests"
+	"io"
+	"log/slog"
+	"net/url"
+	"testing"
+)
+
+func TestNewYaml(t *testing.T) {
+	te := errors.New("Testing_Error")
+
+	type urls struct {
+		f, t *url.URL
+		err  error
+	}
+
+	for _, tc := range []struct {
+		name string
+
+		repo storage.Repository
+		in   io.Reader
+
+		err  error
+		urls []urls
+	}{
+		{
+			name: "Success",
+			repo: memory.NewHashMap(),
+			in: bytes.NewBufferString(`
+---
+- short: //tz3/shortLink
+  long: //tz3/longLink
+- short: //tz3/longLink
+  long: //tz3/baz
+`),
+			urls: []urls{
+				{
+					f: &url.URL{Host: "tz3", Path: "/shortLink"},
+					t: &url.URL{Host: "tz3", Path: "/longLink"},
+				},
+			},
+		},
+		{
+			name: "single line corrupt (tab character)",
+			repo: memory.NewHashMap(),
+			in: bytes.NewBufferString(`
+- short: "//	/shortLink"
+  long: //tz3/longLink
+- short: //tz3/longLink
+  long: //tz3/baz				
+`),
+			urls: []urls{
+				{
+					f:   &url.URL{Host: "	", Path: "/shortLink"},
+					err: storage.ErrorNotFound,
+				},
+			},
+		},
+		{
+			name: "yaml corrupt",
+			repo: memory.NewHashMap(),
+			in:   bytes.NewBufferString(`I'm not yaml!`),
+			err:  storage.ErrorStorageInitFailed,
+		},
+		{
+			name: "storage failure",
+			repo: tests.New(tests.WithError(te)),
+			in: bytes.NewBufferString(`
+---
+- short: //tz3/shortLink
+  long: //tz3/longLink
+- short: //tz3/longLink
+  long: //tz3/baz
+`),
+			err: storage.ErrorStorageInitFailed,
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			y, err := New(tc.repo, tc.in)
+
+			// Validate the error case
+			assert.ErrorIs(t, err, tc.err)
+
+			// Validate State
+			for _, u := range tc.urls {
+				nu, err := y.Get(u.f)
+				assert.ErrorIs(t, err, u.err)
+				assert.Equal(t, u.t, nu)
+			}
+		})
+	}
+}
+
+func TestYamlRejectWrite(t *testing.T) {
+	t.Parallel()
+	y, err := New(memory.NewHashMap(), bytes.NewBufferString("---"))
+
+	assert.Nil(t, err)
+
+	err = y.Set(
+		&url.URL{Host: "tz3", Path: "/shortLink"},
+		&url.URL{Host: "tz3", Path: "/longLink"},
+	)
+
+	assert.ErrorIs(t, err, storage.ErrReadOnlyStorage)
+}
+
+func TestLoggerOverride(t *testing.T) {
+	exist := Log
+	defer func() { Log = exist }()
+
+	// Set up a new logger
+	b := &bytes.Buffer{}
+	Log = slog.New(slog.NewTextHandler(b, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+
+	// Get an error condition (failed URL)
+	New(memory.NewHashMap(), bytes.NewBufferString(`
+- short: "//	/shortLink"
+  long: //tz3/longLink
+`))
+
+	// Validate the output
+	assert.Contains(t, b.String(), "invalid control character")
+}


### PR DESCRIPTION
### Implement yaml handler In this commit (#10): 

## Additions:

1. Adding a simple storage way using yaml storage.
2. Logging -> simple logging (there are better tools/libs) but for this simple project no need to get deeper in this stage.
3. Testing the new storage mechanisim.

## Modifications:

1. Small fix for typo of a commented in functions.

General Info:

1. The yaml introduction is a simple thin wrapper around an exisiting storage (any repository can do the job), which loads the content from a Yaml file into that storage. 
2. This allows Yaml to be used with any number of storage engines,
3. and keeps the implementation very thin.

